### PR TITLE
feat: add command and hotkey to toggle focus mode

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -8,42 +8,63 @@ export default class FocusMode extends Plugin {
             "enter",
             "Toggle Focus Mode (Shift + Click to show active pane only)",
             (event): void => {
-                if (
-                    event.shiftKey ||
-                    // @ts-ignore
-                    this.app.workspace.rootSplit.containerEl.hasClass(
-                        "maximised"
-                    )
-                ) {
-                    // @ts-ignore
-                    this.app.workspace.rootSplit.containerEl.toggleClass(
-                        "maximised",
-                        // @ts-ignore
-                        !this.app.workspace.rootSplit.containerEl.hasClass(
-                            "maximised"
-                        )
-                    );
-                    // @ts-ignore
-                    this.app.workspace.onLayoutChange();
-                }
-
-                const app_container =
-                    // @ts-ignore
-                    this.app.dom.appContainerEl ||
-                    document.querySelector(".app-container");
-
-                app_container.classList.toggle(
-                    "focus-mode",
-                    !app_container.classList.contains("focus-mode")
-                );
-
-                // @ts-ignore
-                this.app.workspace.leftSplit.collapse();
-                // @ts-ignore
-                this.app.workspace.rightSplit.collapse();
+                this.toggleFocus(event.shiftKey);
             }
         );
+        this.addCommand({
+            id: "toggleFocus",
+            name: "Toggle Focus Mode",
+            callback: () => {
+                this.toggleFocus()
+            },
+            hotkeys: [
+              {
+                modifiers: ["Mod", "Alt", "Shift"],
+                key: "f",
+              },
+            ],
+          });
+        this.addCommand({
+            id: "toggleFocus_ActiveOnly",
+            name: "Toggle Focus Mode (show active pane only)",
+            callback: () => {
+                this.toggleFocus(true)
+            },
+          })
     }
+
+    
+    toggleFocus(activeOnly: boolean = false): void {
+        if (
+            activeOnly ||
+            // @ts-ignore
+            this.app.workspace.rootSplit.containerEl.hasClass("maximised")
+        ) {
+            // @ts-ignore
+            this.app.workspace.rootSplit.containerEl.toggleClass(
+                "maximised",
+                // @ts-ignore
+                !this.app.workspace.rootSplit.containerEl.hasClass("maximised")
+            );
+            // @ts-ignore
+            this.app.workspace.onLayoutChange();
+        }
+
+        const app_container =
+            // @ts-ignore
+            this.app.dom.appContainerEl ||
+            document.querySelector(".app-container");
+
+        app_container.classList.toggle(
+            "focus-mode",
+            !app_container.classList.contains("focus-mode")
+        );
+
+        // @ts-ignore
+        this.app.workspace.leftSplit.collapse();
+        // @ts-ignore
+        this.app.workspace.rightSplit.collapse();
+    };
 
     onunload() {
         console.log("Unloading Focus Mode plugin ...");

--- a/main.ts
+++ b/main.ts
@@ -20,7 +20,7 @@ export default class FocusMode extends Plugin {
             hotkeys: [
               {
                 modifiers: ["Mod", "Alt", "Shift"],
-                key: "f",
+                key: "F",
               },
             ],
           });


### PR DESCRIPTION
 use `Ctrl/Cmd + Alt + Shift + F` to toggle regular focus mode

"show active pane only" is not assigned to hotkeys by default