### PR TITLE
fix: transparent effect in California coast theme

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -27,16 +27,11 @@ export default class FocusMode extends Plugin {
                     this.app.workspace.onLayoutChange();
                 }
 
-                const app_container =
-                    // @ts-ignore
-                    this.app.dom.appContainerEl ||
-                    document.querySelector(".app-container");
-
-                app_container.classList.toggle(
+                document.body.classList.toggle(
                     "focus-mode",
-                    !app_container.classList.contains("focus-mode")
+                    !document.body.classList.contains("focus-mode")
                 );
-
+        
                 // @ts-ignore
                 this.app.workspace.leftSplit.collapse();
                 // @ts-ignore

--- a/styles.css
+++ b/styles.css
@@ -3,10 +3,11 @@
     filter: saturate(0.75);
 }
 
-.app-container.focus-mode {
+.focus-mode div.status-bar,
+.focus-mode div.workspace-ribbon {
     visibility: hidden;
 }
-
+.focus-mode div.view-header,
 .focus-mode .workspace-split.maximised .workspace-leaf:not(.mod-active),
 .focus-mode
     .workspace-split.maximised
@@ -14,14 +15,13 @@
     ~ .workspace-split {
     display: none;
 }
+
 .focus-mode .workspace-split.maximised .workspace-leaf.mod-active {
-    // 4px is for scrollbar width:
+    /* 4px is for scrollbar width: */
     flex-basis: calc(100% - 4px);
 }
 
 .focus-mode
-    .side-dock-ribbon-action[aria-label="Toggle Focus Mode (Shift + Click to show active pane only)"],
-.focus-mode .view-content {
-    display: block;
+    .side-dock-ribbon-action[aria-label="Toggle Focus Mode (Shift + Click to show active pane only)"] {
     visibility: visible;
 }


### PR DESCRIPTION
- use `document.body` as status indicator
- use blacklist fliter in css for precise control
- not display `view-header` instead of hidding it

Result: 

| Before | After |
|:--:|:--:|
|![image](https://user-images.githubusercontent.com/31102694/119079384-95d3a380-ba2a-11eb-9c4c-03d5192a7dc8.png)|![image](https://user-images.githubusercontent.com/31102694/119079350-85232d80-ba2a-11eb-928d-e11ca9e28ecc.png)|