### PR TITLE
Revert "fix(styles.css): fix issues with obsidian-tabs"

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -38,13 +38,3 @@
     .side-dock-ribbon-action[aria-label="Toggle Focus Mode (Shift + Click to show active pane only)"] {
     visibility: visible;
 }
-
-.focus-mode.plugin-tabs .stayopen div.view-header {
-  display: none;
-}
-.focus-mode.plugin-tabs div.view-header {
-  display: flex;
-}
-.focus-mode.plugin-tabs div.view-actions {
-  display: none;
-}


### PR DESCRIPTION
The Obsidian Tabs plugin pushed out a fix before I could release this, so we will revert it for now.